### PR TITLE
Include OpenSSL's bio.h.

### DIFF
--- a/src/lib/openssl_crypto.c
+++ b/src/lib/openssl_crypto.c
@@ -22,6 +22,7 @@
 /** \file
  */
 
+#include <openssl/bio.h>
 #include <openssl/md5.h>
 #include <openssl/sha.h>
 #include <openssl/dsa.h>


### PR DESCRIPTION
crypto_openssl.c uses functions from bio.h but does not include it. This
happens to work with current versions of OpenSSL because other OpenSSL
headers happen to include bio.h. However, this might not be true of
future versions and so is fragile.
